### PR TITLE
subshape avoids producing vars on slice inputs

### DIFF
--- a/datashape/coretypes.py
+++ b/datashape/coretypes.py
@@ -9,6 +9,7 @@ shape and data type.
 import ctypes
 import datetime
 import operator
+from math import ceil
 
 import numpy as np
 
@@ -545,7 +546,7 @@ class DataShape(Mono):
         3 * { name : string, amount : int32 }
 
         >>> print(ds.subshape[0:7:2, 'amount'])
-        3 * int32
+        4 * int32
 
         >>> print(ds.subshape[[1, 10, 15]])
         3 * { name : string, amount : int32 }
@@ -592,7 +593,7 @@ class DataShape(Mono):
                 stop = index.stop or int(self[0])
                 count = stop - start
                 if index.step is not None:
-                    count //= index.step
+                    count = int(ceil(count / index.step))
                 return count * self.subarray(1)
             else:
                 return var * self.subarray(1)

--- a/datashape/tests/test_coretypes.py
+++ b/datashape/tests/test_coretypes.py
@@ -92,3 +92,6 @@ def test_serializable():
 def test_subshape():
     ds = dshape('5 * 3 * float32')
     assert ds.subshape[2:] == dshape('3 * 3 * float32')
+
+    ds = dshape('5 * 3 * float32')
+    assert ds.subshape[::2] == dshape('3 * 3 * float32')


### PR DESCRIPTION
### Before

``` Python
In [1]: from datashape import dshape

In [2]: ds = dshape('5 * 3 * int32')

In [3]: ds.subshape[2:, 0]
Out[3]: dshape("var * int32")
```
### After

``` Python
In [1]: from datashape import dshape

In [2]: ds = dshape('5 * 3 * int32')

In [3]: ds.subshape[2:, 0]
Out[3]: dshape("3 * int32")
```
