### PR TITLE
consistent str of datashapes with timezone info

### DIFF
--- a/datashape/coretypes.py
+++ b/datashape/coretypes.py
@@ -272,7 +272,7 @@ class Time(Unit):
         if self.tz is None:
             return 'time'
         else:
-            return 'time[tz=%r]' % self.tz
+            return 'time[tz=%r]' % str(self.tz)
 
 
 class DateTime(Unit):
@@ -291,7 +291,7 @@ class DateTime(Unit):
         if self.tz is None:
             return 'datetime'
         else:
-            return 'datetime[tz=%r]' % self.tz
+            return 'datetime[tz=%r]' % str(self.tz)
 
     def to_numpy_dtype(self):
         return np.dtype('datetime64[us]')

--- a/datashape/tests/test_creation.py
+++ b/datashape/tests/test_creation.py
@@ -86,12 +86,14 @@ class TestDataShapeCreation(unittest.TestCase):
         self.assertEqual(dshape('time[tz="UTC"]')[0].tz, 'UTC')
         self.assertEqual(dshape('time[tz="America/Vancouver"]')[0].tz,
                          'America/Vancouver')
+        self.assertEqual(str(dshape('time[tz="UTC"]')), "time[tz='UTC']")
 
     def test_datetime(self):
         self.assertEqual(dshape('datetime')[0].tz, None)
         self.assertEqual(dshape('datetime[tz="UTC"]')[0].tz, 'UTC')
         self.assertEqual(dshape('datetime[tz="America/Vancouver"]')[0].tz,
                          'America/Vancouver')
+        self.assertEqual(str(dshape('datetime[tz="UTC"]')), "datetime[tz='UTC']")
 
     def test_units(self):
         self.assertEqual(dshape('units["second"]')[0].unit, 'second')


### PR DESCRIPTION
Makes `__str__` of datashapes with timezone information consistent
between Python 2 and Python 3.

Before (in Python 2.x):

```
>>> str(datashape.dshape("datetime[tz='UTC']"))
"datetime[tz=u'UTC']"
```

After:

```
>>> str(datashape.dshape("datetime[tz='UTC']"))
"datetime[tz='UTC']"
```

Before and After in Python 3.x: (no change)

```
>>> str(datashape.dshape("datetime[tz='UTC']"))
"datetime[tz='UTC']"
```
