### PR TITLE
to_numpy_dtype ignores dimensions

### DIFF
--- a/datashape/coretypes.py
+++ b/datashape/coretypes.py
@@ -1050,7 +1050,7 @@ class NotNumpyCompatible(Exception):
 def to_numpy_dtype(ds):
     """ Throw away the shape information and just return the
     measure as NumPy dtype instance."""
-    return to_numpy(ds)[1]
+    return to_numpy(ds.measure)[1]
 
 def to_numpy(ds):
     """

--- a/datashape/tests/test_coretypes.py
+++ b/datashape/tests/test_coretypes.py
@@ -40,6 +40,9 @@ class TestToNumpyDtype(object):
     def test_string(self):
         assert to_numpy_dtype(dshape('2 * string')) == np.dtype('O')
 
+    def test_dimensions(self):
+        return to_numpy_dtype(dshape('var * int32')) == np.int32
+
 
 class TestFromNumPyDtype(object):
 


### PR DESCRIPTION
This is useful if the dimension is var, and so would raise an error in
`to_numpy`
