### PR TITLE
launder inputs to Option

### DIFF
--- a/datashape/tests/test_coretypes.py
+++ b/datashape/tests/test_coretypes.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 
 from datashape.coretypes import (Record, real, String, CType, DataShape, int32,
-        Fixed)
+        Fixed, Option)
 from datashape import dshape, to_numpy_dtype, from_numpy
 
 
@@ -104,3 +104,14 @@ def test_subshape():
 def test_DataShape_coerces_ints():
     assert DataShape(5, 'int32')[0] == Fixed(5)
     assert DataShape(5, 'int32')[1] == int32
+
+
+def test_shape():
+    assert dshape('5 * 3 * float32').shape == (5, 3)
+    assert dshape('float32').shape == ()
+    assert dshape('float32').measure.shape == ()
+    assert dshape('?float32').measure.shape == ()
+
+
+def test_option_sanitizes_strings():
+    assert Option('float32').ty == dshape('float32').measure


### PR DESCRIPTION
We unify input cleaning functions `_launder` and `normalize` into a single function, `_launder`.  We also apply this function in the `Option` constructor.
