### PR TITLE
Record types add quotes around names with spaces

### DIFF
--- a/datashape/coretypes.py
+++ b/datashape/coretypes.py
@@ -1173,10 +1173,10 @@ def normalize_string(s):
     >>> normalize_string('Hello')
     'Hello'
     >>> normalize_string('Hello world')
-    '"Hello world"'
+    "'Hello world'"
     """
     if ' ' in s:
-        s = '"%s"' % s
+        s = "'%s'" % s
     return s
 
 def record_string(fields, values):

--- a/datashape/tests/test_coretypes.py
+++ b/datashape/tests/test_coretypes.py
@@ -121,3 +121,6 @@ def test_record_type_uses_quotes_when_spaces_are_in_name():
     s = "{ 'column name' : int32 }"
     assert ("'column name'" in str(dshape(s)) or
             '"column name"' in str(dshape(s)))
+
+    ds = dshape(s)
+    assert eval(repr(ds)) == ds


### PR DESCRIPTION
### Before

``` Python
In [1]: import datashape

In [2]: datashape.dshape('{"column name": int32}')
Out[2]: dshape("{ column name : int32 }")
```
### After

``` Python
In [1]: import datashape

In [2]: datashape.dshape('{"column name": int32}')
Out[2]: dshape("{ 'column name' : int32 }")
```
