### PR TITLE
Discover on object arrays checks for string values

### DIFF
--- a/datashape/tests/test_discovery.py
+++ b/datashape/tests/test_discovery.py
@@ -129,6 +129,17 @@ def test_numpy_array():
     assert discover(np.ones((3, 2), dtype=np.int32)) == dshape('3 * 2 * int32')
 
 
+def test_numpy_array_with_strings():
+    x = np.array(['Hello', 'world'], dtype='O')
+    assert discover(x) == 2 * string
+
+
+def test_numpy_recarray_with_strings():
+    x = np.array([('Alice', 1), ('Bob', 2)],
+            dtype=[('name', 'O'), ('amt', 'i4')])
+    assert discover(x) == dshape('2 * {name: string, amt: int32}')
+
+
 unite = do_one([unite_identical,
                 unite_merge_dimensions,
                 unite_base])


### PR DESCRIPTION
``` Python
In [1]: from datashape import discover
In [2]: import numpy as np
In [3]: x = np.array([('Alice', 1), ('Bob', 2)], dtype=[('name', 'O'), ('amt', 'i4')])

# Before
In [4]: discover(x)
Out[4]: dshape("2 * {name: object, amt: int32}")

# After
In [4]: discover(x)
Out[4]: dshape("2 * {name: string, amt: int32}")
```

This checks the first five values of all arrays identified as `object` type.  If all five are strings then it calls it a string column.  This is less conservative.
