### PR TITLE
DEV: adds datashape.util.testing.assert_dshape_equal

### DIFF
--- a/datashape/py2help.py
+++ b/datashape/py2help.py
@@ -43,6 +43,12 @@ else:
     _strtypes = (str,)
 
 
+def with_metaclass(metaclass, *bases):
+    """Helper for using metaclasses in a py2/3 compatible way.
+    """
+    return metaclass('_', bases, {})
+
+
 try:
     from collections import OrderedDict
 except ImportError:

--- a/datashape/util/__init__.py
+++ b/datashape/util/__init__.py
@@ -1,16 +1,16 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function, division, absolute_import
 
+from itertools import chain
 import operator
 import ctypes
 import sys
 
-from . import py2help
-from . import parser
-from . import type_symbol_table
-from .validation import validate
-from . import coretypes
-from itertools import chain
+from .. import py2help
+from .. import parser
+from .. import type_symbol_table
+from ..validation import validate
+from .. import coretypes
 
 
 __all__ = 'dshape', 'dshapes', 'has_var_dim', 'has_ellipsis', 'cat_dshapes'

--- a/datashape/util/testing.py
+++ b/datashape/util/testing.py
@@ -93,32 +93,25 @@ def _check_slots(a, b, path=None, **kwargs):
     if type(a) != type(b):
         return _base_case(a, b, path=path, **kwargs)
 
-    if a.__slots__ != b.__slots__:
-        raise AssertionError(
-            'slots mismatch: %r != %r\n%s' % (
-                a.__slots__, b.__slots__, _fmt_path(path),
-            ),
-        )
+    assert a.__slots__ == b.__slots__, 'slots mismatch: %r != %r\n%s' % (
+        a.__slots__, b.__slots__, _fmt_path(path),
+    )
     if path is None:
         path = ()
     for slot in a.__slots__:
-        if getattr(a, slot) != getattr(b, slot):
-            path += '.' + slot,
-            raise AssertionError(
-                "%s %ss do not match: %r != %r\n%s" % (
-                    type(a).__name__.lower(),
-                    slot,
-                    getattr(a, slot),
-                    getattr(b, slot),
-                    _fmt_path(path),
-                ),
+        assert getattr(a, slot) == getattr(b, slot), \
+            "%s %ss do not match: %r != %r\n%s" % (
+                type(a).__name__.lower(),
+                slot,
+                getattr(a, slot),
+                getattr(b, slot),
+                _fmt_path(path + ('.' + slot,)),
             )
 
 
 @assert_dshape_equal.register(object, object)
 def _base_case(a, b, path=None, **kwargs):
-    if a != b:
-        raise AssertionError('%s != %s\n%s' % (a, b, _fmt_path(path)))
+    assert a == b, '%s != %s\n%s' % (a, b, _fmt_path(path))
 
 
 @dispatch((DateTime, Time), (DateTime, Time))
@@ -140,13 +133,9 @@ def assert_dshape_equal(a, b, path=None, **kwargs):
     if path is None:
         path = ()
 
-    if a.unit != b.unit:
-        path += '.unit',
-        raise AssertionError(
-            '%s units do not match: %r != %s\n%s' % (
-                type(a).__name__.lower(), a.unit, b.unit, _fmt_path(path),
-            ),
-        )
+    assert a.unit == b.unit, '%s units do not match: %r != %s\n%s' % (
+        type(a).__name__.lower(), a.unit, b.unit, _fmt_path(path + ('.unit',)),
+    )
 
     path.append('.tp')
     assert_dshape_equal(a.tp, b.tp, **kwargs)
@@ -161,20 +150,17 @@ def assert_dshape_equal(a,
                         **kwargs):
     if path is None:
         path = ()
-    if check_str_encoding and a.encoding != b.encoding:
-        path += '.encoding',
-        raise AssertionError(
+    if check_str_encoding:
+        assert a.encoding == b.encoding, \
             'string encodings do not match: %r != %r\n%s' % (
-                a.encoding, b.encoding, _fmt_path(path),
-            ),
-        )
-    if check_str_fixlen and a.fixlen != b.fixlen:
-        path += '.fixlen',
-        raise AssertionError(
+                a.encoding, b.encoding, _fmt_path(path + ('.encoding',)),
+            )
+
+    if check_str_fixlen:
+        assert a.fixlen == b.fixlen, \
             'string fixlens do not match: %d != %d\n%s' % (
-                a.fixlen, b.fixlen, _fmt_path(path),
-            ),
-        )
+                a.fixlen, b.fixlen, _fmt_path(path + ('.fixlen',)),
+            )
 
 
 @dispatch(Option, Option)
@@ -190,11 +176,9 @@ def assert_dshape_equal(a, b, check_record_order=True, path=None, **kwargs):
     afields = a.fields
     bfields = b.fields
 
-    if len(afields) != len(bfields):
-        raise AssertionError(
-            'records have mismatched field counts: %d != %d\n%r != %r\n%s' % (
-                len(afields), len(bfields), a, b, _fmt_path(path),
-            ),
+    assert len(afields) == len(bfields), \
+        'records have mismatched field counts: %d != %d\n%r != %r\n%s' % (
+            len(afields), len(bfields), a, b, _fmt_path(path),
         )
 
     if not check_record_order:
@@ -206,10 +190,9 @@ def assert_dshape_equal(a, b, check_record_order=True, path=None, **kwargs):
     for n, ((aname, afield), (bname, bfield)) in enumerate(
             zip(afields, bfields)):
 
-        if aname != bname:
-            raise AssertionError(
-                'record field name at position %d does not match: %r != %r\n%s'
-                % (n, aname, bname, _fmt_path(path)),
+        assert aname == bname, \
+            'record field name at position %d does not match: %r != %r\n%s' % (
+                n, aname, bname, _fmt_path(path),
             )
 
         assert_dshape_equal(
@@ -222,12 +205,11 @@ def assert_dshape_equal(a, b, check_record_order=True, path=None, **kwargs):
 
 @dispatch(Tuple, Tuple)
 def assert_dshape_equal(a, b, path=None, **kwargs):
-    if len(a.dshapes) != len(b.dshapes):
-        raise AssertionError(
-            'tuples have mismatched field counts: %d !+ %d\n%r != %r\n%s' % (
-                len(a.dshapes), len(b.dshapes), a, b, _fmt_path(path),
-            ),
+    assert len(a.dshapes) == len(b.dshapes), \
+        'tuples have mismatched field counts: %d !+ %d\n%r != %r\n%s' % (
+            len(a.dshapes), len(b.dshapes), a, b, _fmt_path(path),
         )
+
     if path is None:
         path = ()
     path += '.dshapes',

--- a/datashape/util/testing.py
+++ b/datashape/util/testing.py
@@ -1,0 +1,240 @@
+from abc import ABCMeta
+
+from ..py2help import with_metaclass
+from ..coretypes import (
+    DataShape,
+    DateTime,
+    Option,
+    Record,
+    String,
+    Time,
+    TimeDelta,
+    Tuple,
+    Units,
+)
+from ..dispatch import dispatch
+
+
+def _fmt_path(path):
+    """Format the path for final display.
+
+    Parameters
+    ----------
+    path : iterable of str
+        The path to the values that are not equal.
+
+    Returns
+    -------
+    fmtd : str
+        The formatted path to put into the error message.
+    """
+    if not path:
+        return ''
+    return 'path: _' + ''.join(path)
+
+
+@dispatch(DataShape, DataShape)
+def assert_dshape_equal(a, b, check_dim=True, path=None, **kwargs):
+    ashape = a.shape
+    bshape = b.shape
+
+    if path is None:
+        path = ()
+
+    if check_dim:
+        for n, (adim, bdim) in enumerate(zip(ashape, bshape)):
+            if adim != bdim:
+                path += '.shape[%d]' % n,
+                raise AssertionError(
+                    'dimensions do not match: %s != %s%s\n%s' % (
+                        adim,
+                        bdim,
+                        ('\n%s != %s' % (
+                            ' * '.join(map(str, ashape)),
+                            ' * '.join(map(str, bshape)),
+                        )) if len(a.shape) > 1 else '',
+                        _fmt_path(path),
+                    ),
+                )
+
+    path += '.measure',
+    assert_dshape_equal(
+        a.measure,
+        b.measure,
+        check_dim=check_dim,
+        path=path,
+        **kwargs
+    )
+
+
+class Slotted(with_metaclass(ABCMeta)):
+    @classmethod
+    def __subclasshook__(cls, subcls):
+        return hasattr(subcls, '__slots__')
+
+
+@assert_dshape_equal.register(Slotted, Slotted)
+def _check_slots(a, b, path=None, **kwargs):
+    """Genric checker that iterates over the ``__slots__`` and asserts they
+    are equal. This is a non-recursive function.
+
+    Parameters
+    ----------
+    a, b : Slotted
+        The shapes to check.
+    path : iteratable of str, optional
+        The path to the current ``a`` and ``b`` values.
+
+    Raises
+    ------
+    AssertionError
+        When the slots of ``a`` and ``b`` are not equal.
+    """
+    if type(a) != type(b):
+        return _base_case(a, b, path=path, **kwargs)
+
+    if a.__slots__ != b.__slots__:
+        raise AssertionError(
+            'slots mismatch: %r != %r\n%s' % (
+                a.__slots__, b.__slots__, _fmt_path(path),
+            ),
+        )
+    if path is None:
+        path = ()
+    for slot in a.__slots__:
+        if getattr(a, slot) != getattr(b, slot):
+            path += '.' + slot,
+            raise AssertionError(
+                "%s %ss do not match: %r != %r\n%s" % (
+                    type(a).__name__.lower(),
+                    slot,
+                    getattr(a, slot),
+                    getattr(b, slot),
+                    _fmt_path(path),
+                ),
+            )
+
+
+@assert_dshape_equal.register(object, object)
+def _base_case(a, b, path=None, **kwargs):
+    if a != b:
+        raise AssertionError('%s != %s\n%s' % (a, b, _fmt_path(path)))
+
+
+@dispatch((DateTime, Time), (DateTime, Time))
+def assert_dshape_equal(a, b, path=None, check_tz=True, **kwargs):
+    if type(a) != type(b):
+        return _base_case(a, b)
+    if check_tz:
+        _check_slots(a, b, path)
+
+
+@dispatch(TimeDelta, TimeDelta)
+def assert_dshape_equal(a, b, path=None, check_timedelta_unit=True, **kwargs):
+    if check_timedelta_unit:
+        _check_slots(a, b, path)
+
+
+@dispatch(Units, Units)
+def assert_dshape_equal(a, b, path=None, **kwargs):
+    if path is None:
+        path = ()
+
+    if a.unit != b.unit:
+        path += '.unit',
+        raise AssertionError(
+            '%s units do not match: %r != %s\n%s' % (
+                type(a).__name__.lower(), a.unit, b.unit, _fmt_path(path),
+            ),
+        )
+
+    path.append('.tp')
+    assert_dshape_equal(a.tp, b.tp, **kwargs)
+
+
+@dispatch(String, String)
+def assert_dshape_equal(a,
+                        b,
+                        path=None,
+                        check_str_encoding=True,
+                        check_str_fixlen=True,
+                        **kwargs):
+    if path is None:
+        path = ()
+    if check_str_encoding and a.encoding != b.encoding:
+        path += '.encoding',
+        raise AssertionError(
+            'string encodings do not match: %r != %r\n%s' % (
+                a.encoding, b.encoding, _fmt_path(path),
+            ),
+        )
+    if check_str_fixlen and a.fixlen != b.fixlen:
+        path += '.fixlen',
+        raise AssertionError(
+            'string fixlens do not match: %d != %d\n%s' % (
+                a.fixlen, b.fixlen, _fmt_path(path),
+            ),
+        )
+
+
+@dispatch(Option, Option)
+def assert_dshape_equal(a, b, path=None, **kwargs):
+    if path is None:
+        path = ()
+    path += '.ty',
+    return assert_dshape_equal(a.ty, b.ty, path=path, **kwargs)
+
+
+@dispatch(Record, Record)
+def assert_dshape_equal(a, b, check_record_order=True, path=None, **kwargs):
+    afields = a.fields
+    bfields = b.fields
+
+    if len(afields) != len(bfields):
+        raise AssertionError(
+            'records have mismatched field counts: %d != %d\n%r != %r\n%s' % (
+                len(afields), len(bfields), a, b, _fmt_path(path),
+            ),
+        )
+
+    if not check_record_order:
+        afields = sorted(afields)
+        bfields = sorted(bfields)
+
+    if path is None:
+        path = ()
+    for n, ((aname, afield), (bname, bfield)) in enumerate(
+            zip(afields, bfields)):
+
+        if aname != bname:
+            raise AssertionError(
+                'record field name at position %d does not match: %r != %r\n%s'
+                % (n, aname, bname, _fmt_path(path)),
+            )
+
+        assert_dshape_equal(
+            afield,
+            bfield,
+            path=path + ('[%s]' % repr(aname),),
+            **kwargs
+        )
+
+
+@dispatch(Tuple, Tuple)
+def assert_dshape_equal(a, b, path=None, **kwargs):
+    if len(a.dshapes) != len(b.dshapes):
+        raise AssertionError(
+            'tuples have mismatched field counts: %d !+ %d\n%r != %r\n%s' % (
+                len(a.dshapes), len(b.dshapes), a, b, _fmt_path(path),
+            ),
+        )
+    if path is None:
+        path = ()
+    path += '.dshapes',
+    for n, (ashape, bshape) in enumerate(zip(a.dshapes, b.dshapes)):
+        assert_dshape_equal(
+            ashape,
+            bshape,
+            path=path + ('[%d]' % n,),
+            **kwargs
+        )

--- a/datashape/util/testing.py
+++ b/datashape/util/testing.py
@@ -106,21 +106,6 @@ class Slotted(with_metaclass(ABCMeta)):
 
 @assert_dshape_equal.register(Slotted, Slotted)
 def _check_slots(a, b, path=None, **kwargs):
-    """Genric checker that iterates over the ``__slots__`` and asserts they
-    are equal. This is a non-recursive function.
-
-    Parameters
-    ----------
-    a, b : Slotted
-        The shapes to check.
-    path : iteratable of str, optional
-        The path to the current ``a`` and ``b`` values.
-
-    Raises
-    ------
-    AssertionError
-        Raised when the slots of ``a`` and ``b`` are not equal.
-    """
     if type(a) != type(b):
         return _base_case(a, b, path=path, **kwargs)
 

--- a/datashape/util/testing.py
+++ b/datashape/util/testing.py
@@ -35,6 +35,37 @@ def _fmt_path(path):
 
 @dispatch(DataShape, DataShape)
 def assert_dshape_equal(a, b, check_dim=True, path=None, **kwargs):
+    """Assert that two dshapes are equal, providing an informative error
+    message when they are not equal.
+
+    Parameters
+    ----------
+    a, b : dshape
+        The dshapes to check for equality.
+    check_dim : bool, optional
+        Check shapes for equality with respect to their dimensions.
+        default: True
+    check_tz : bool, optional
+        Checks times and datetimes for equality with respect to timezones.
+        default: True
+    check_timedelta_unit : bool, optional
+        Checks timedeltas for equality with respect to their unit (us, ns, ...).
+        default: True
+    check_str_encoding : bool, optional
+        Checks strings for equality with respect to their encoding.
+        default: True
+    check_str_fixlen : bool, optional
+        Checks string for equality with respect to their fixlen.
+        default: True
+    check_record_order : bool, optional
+        Checks records for equality with respect to the order of the fields.
+        default: True
+
+    Raises
+    ------
+    AssertionError
+        Raised when the two dshapes are not equal.
+    """
     ashape = a.shape
     bshape = b.shape
 
@@ -88,7 +119,7 @@ def _check_slots(a, b, path=None, **kwargs):
     Raises
     ------
     AssertionError
-        When the slots of ``a`` and ``b`` are not equal.
+        Raised when the slots of ``a`` and ``b`` are not equal.
     """
     if type(a) != type(b):
         return _base_case(a, b, path=path, **kwargs)

--- a/datashape/util/tests/test_testing.py
+++ b/datashape/util/tests/test_testing.py
@@ -1,0 +1,192 @@
+"""Testing the test helpers.
+
+Kill me now.
+"""
+import pytest
+
+from datashape.coretypes import (
+    DateTime,
+    Record,
+    String,
+    Time,
+    TimeDelta,
+    Tuple,
+    Option,
+    int32,
+    float32,
+)
+from datashape.py2help import PY2
+from datashape.util import dshape
+from datashape.util.testing import assert_dshape_equal
+
+
+def test_datashape_measure():
+    assert_dshape_equal(dshape('int'), dshape('int'))
+
+    with pytest.raises(AssertionError) as e:
+        assert_dshape_equal(dshape('int'), dshape('string'))
+    assert 'int32 != string' in str(e.value)
+    assert '_.measure' in str(e.value)
+
+
+def test_dim():
+    assert_dshape_equal(dshape('var * int'), dshape('var * int'))
+    assert_dshape_equal(dshape('3 * string'), dshape('3 * string'))
+
+    with pytest.raises(AssertionError) as e:
+        assert_dshape_equal(dshape('var * int'), dshape('3 * int'))
+    assert 'var != 3' in str(e.value)
+    assert '_.shape[0]' in str(e.value)
+
+    assert_dshape_equal(dshape('var * var * int'), dshape('var * var * int'))
+    assert_dshape_equal(dshape('var * 3 * string'), dshape('var * 3 * string'))
+    assert_dshape_equal(
+        dshape('3 * var * float32'),
+        dshape('3 * var * float32'),
+    )
+    assert_dshape_equal(
+        dshape('3 * 3 * datetime'),
+        dshape('3 * 3 * datetime'),
+    )
+
+    with pytest.raises(AssertionError) as e:
+        assert_dshape_equal(
+            dshape('var * var * int'),
+            dshape('3 * var * int'),
+        )
+    assert 'var != 3' in str(e.value)
+    assert '_.shape[0]' in str(e.value)
+
+    with pytest.raises(AssertionError) as e:
+        assert_dshape_equal(
+            dshape('var * var * int'),
+            dshape('var * 3 * int'),
+        )
+    assert 'var != 3' in str(e.value)
+    assert '_.shape[1]' in str(e.value)
+
+
+def test_record():
+    assert_dshape_equal(
+        Record((('a', int32), ('b', float32))),
+        Record((('a', int32), ('b', float32))),
+    )
+
+    with pytest.raises(AssertionError) as e:
+        assert_dshape_equal(
+            Record((('a', int32), ('b', float32))),
+            Record((('a', int32), ('b', int32))),
+        )
+    assert "'float32' != 'int32'" in str(e)
+    assert "_['b'].name" in str(e.value)
+
+    with pytest.raises(AssertionError) as e:
+        assert_dshape_equal(
+            Record((('a', int32), ('b', float32))),
+            Record((('a', int32), ('c', float32))),
+        )
+    assert "'b' != 'c'" in str(e.value)
+
+    assert_dshape_equal(
+        Record((('b', float32), ('a', int32))),
+        Record((('a', int32), ('b', float32))),
+        check_record_order=False,
+    )
+
+    with pytest.raises(AssertionError) as e:
+        assert_dshape_equal(
+            Record((('b', float32), ('a', float32))),
+            Record((('a', int32), ('b', float32))),
+            check_record_order=False,
+        )
+    assert "'float32' != 'int32'" in str(e.value)
+    assert "_['a']" in str(e.value)
+
+
+def test_tuple():
+    assert_dshape_equal(Tuple((int32, float32)), Tuple((int32, float32)))
+
+    with pytest.raises(AssertionError) as e:
+        assert_dshape_equal(Tuple((int32, float32)), Tuple((int32, int32)))
+    assert "'float32' != 'int32'" in str(e)
+    assert "_.dshapes[1].measure.name" in str(e.value)
+
+    with pytest.raises(AssertionError) as e:
+        assert_dshape_equal(Tuple((int32, float32)), Tuple((int32, int32)))
+    assert "'float32' != 'int32'" in str(e)
+    assert '_.dshapes[1].measure.name' in str(e.value)
+
+
+def test_option():
+    assert_dshape_equal(Option(int32), Option(int32))
+
+    with pytest.raises(AssertionError) as e:
+        assert_dshape_equal(Option(int32), Option(float32))
+    assert "'int32' != 'float32'" in str(e.value)
+    assert '_.ty' in str(e.value)
+
+
+def test_string():
+    assert_dshape_equal(String(), String())
+    assert_dshape_equal(String('U8'), String('U8'))
+    assert_dshape_equal(String(1), String(1))
+    assert_dshape_equal(String(1, 'U8'), String(1, 'U8'))
+
+    with pytest.raises(AssertionError) as e:
+        assert_dshape_equal(String('U8'), String('U16'))
+
+    assert "{u}'U8' != {u}'U16'".format(u='u' if PY2 else '') in str(e.value)
+    assert '_.encoding' in str(e.value)
+
+    with pytest.raises(AssertionError) as e:
+        assert_dshape_equal(String(1), String(2))
+    assert '1 != 2' in str(e.value)
+    assert '_.fixlen' in str(e.value)
+
+
+def test_timedelta():
+    assert_dshape_equal(TimeDelta(), TimeDelta())
+    assert_dshape_equal(TimeDelta('ns'), TimeDelta('ns'))
+
+    with pytest.raises(AssertionError) as e:
+        assert_dshape_equal(TimeDelta('us'), TimeDelta('ns'))
+    assert "'us' != 'ns'" in str(e.value)
+    assert '_.unit' in str(e.value)
+
+    assert_dshape_equal(
+        TimeDelta('us'),
+        TimeDelta('ns'),
+        check_timedelta_unit=False,
+    )
+
+
+@pytest.mark.parametrize('cls', (DateTime, Time))
+def test_datetime(cls):
+    assert_dshape_equal(cls(), cls())
+    assert_dshape_equal(cls('US/Eastern'), cls('US/Eastern'))
+
+    with pytest.raises(AssertionError) as e:
+        assert_dshape_equal(cls('US/Eastern'), cls('US/Central'))
+    assert "'US/Eastern' != 'US/Central'" in str(e.value)
+    assert '_.tz' in str(e.value)
+
+    assert_dshape_equal(
+        cls('US/Eastern'),
+        cls('US/Central'),
+        check_tz=False,
+    )
+
+
+def test_nested():
+    assert_dshape_equal(
+        dshape('var * {a: 3 * {b: int32}}'),
+        dshape('var * {a: 3 * {b: int32}}'),
+    )
+
+    with pytest.raises(AssertionError) as e:
+        assert_dshape_equal(
+            dshape('var * {a: 3 * {b: int32}}'),
+            dshape('var * {a: 3 * {b: float32}}'),
+        )
+    assert "'int32' != 'float32'" in str(e.value)
+    assert "_.measure['a'].measure['b'].name" in str(e.value)

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     license='BSD',
     keywords='data language',
     url='http://datashape.readthedocs.org/en/latest/',
-    packages=['datashape', 'datashape.tests'],
+    packages=['datashape', 'datashape.util', 'datashape.tests'],
     install_requires=read('requirements.txt').strip().split('\n'),
     long_description=read('README.rst'),
     zip_safe=False,


### PR DESCRIPTION
I find that when writing tests with datashape I have a hard time figuring out which part of the dshape is not equal which leads to a slower debug process.
This adds an `assert_dshape_equal` function which aims to provide much better errors. One of the nice pieces `path: %s` part of the message that shows you the exact path to the parts that are not equal, here are some examples:

```python
In [2]: assert_dshape_equal(dshape('var * int32'), dshape('var * float64'))
AssertionError: ctype names do not match: 'int32' != 'float64'
path: _.measure.name

In [3]: assert_dshape_equal(dshape('2 * int32'), dshape('var * int32'))
AssertionError: dimensions do not match: 2 != var
path: _.shape[0]

In [4]: assert_dshape_equal(dshape('var * 2 * int32'), dshape('var * 3 * int32'))
AssertionError: dimensions do not match: 2 != 3
var * 2 != var * 3
path: _.shape[1]

In [6]: assert_dshape_equal(dshape('var * {a: 3 * {b: int32}}'), dshape('var * {a: 3 * {b: float32}}')) 
AssertionError: ctype names do not match: 'int32' != 'float32'
path: _.measure['a'].measure['b'].name
```

I do not want to refactor the current tests to use this because I don't want to break anything (there are no tests for the tests); however, it would be nice to use something like this going forward.