### PR TITLE
Allows Option(Option(A))

### DIFF
--- a/datashape/coretypes.py
+++ b/datashape/coretypes.py
@@ -53,7 +53,10 @@ class Type(type):
 
     @classmethod
     def lookup_type(cls, name):
-        return cls._registry[name]
+        try:
+            return cls._registry[name]
+        except KeyError:
+            raise KeyError('Unknown type %r' % name)
 
 
 class Mono(object):
@@ -917,7 +920,7 @@ def _launder(x):
     if isinstance(x, _inttypes):
         x = Fixed(x)
     if isinstance(x, _strtypes):
-        return Type.lookup_type(x)
+        x = datashape.dshape(x)
     if isinstance(x, DataShape) and len(x) == 1:
         return x[0]
     return x

--- a/datashape/error.py
+++ b/datashape/error.py
@@ -9,7 +9,8 @@ syntax_error = """
 {error}: {msg}
 """
 
-class DataShapeSyntaxError(SyntaxError):
+
+class DataShapeSyntaxError(Exception):
     """
     Makes datashape parse errors look like Python SyntaxError.
     """

--- a/datashape/parser.py
+++ b/datashape/parser.py
@@ -11,6 +11,7 @@ from . import coretypes
 
 __all__ = ['parse']
 
+
 class DataShapeParser(object):
     """A DataShape parser object."""
     def __init__(self, ds_str, sym):
@@ -123,6 +124,7 @@ class DataShapeParser(object):
     def parse_datashape(self):
         """
         datashape : datashape_nooption
+                  | QUESTIONMARK datashape
                   | QUESTIONMARK datashape_nooption
                   | EXCLAMATIONMARK datashape_nooption
 
@@ -133,14 +135,19 @@ class DataShapeParser(object):
         if tok.id in constructors:
             self.advance_tok()
             saved_pos = self.pos
-            ds = self.parse_datashape_nooption()
+            option = self.syntactic_sugar(
+                self.sym.dtype_constr,
+                constructors[tok.id],
+                '%s dtype construction' % constructors[tok.id],
+                saved_pos - 1,
+            )
+            if self.tok.id in constructors:
+                ds = self.parse_datashape()
+            else:
+                ds = self.parse_datashape_nooption()
             if ds is not None:
-                # Look in the dtype symbol table for the option type constructor
-                option = self.syntactic_sugar(self.sym.dtype_constr,
-                                              constructors[tok.id],
-                                              '%s dtype construction' %
-                                              constructors[tok.id],
-                                              saved_pos - 1)
+                # Look in the dtype symbol table for the option type
+                # constructor
                 return coretypes.DataShape(option(ds))
         else:
             return self.parse_datashape_nooption()

--- a/datashape/tests/test_parser.py
+++ b/datashape/tests/test_parser.py
@@ -8,9 +8,9 @@ import unittest
 import pytest
 
 import datashape
+from datashape import coretypes as ct, DataShapeSyntaxError
 from datashape.parser import parse
-from datashape import coretypes as ct
-from datashape import DataShapeSyntaxError
+from datashape.util.testing import assert_dshape_equal
 
 
 @pytest.fixture
@@ -97,24 +97,28 @@ class TestDataShapeParseBasicDType(unittest.TestCase):
                          parse('complex[float64]', self.sym))
 
     def test_option(self):
-        self.assertEqual(parse('option[int32]', self.sym),
-                         ct.DataShape(ct.Option(ct.int32)))
-        self.assertEqual(parse('?int32', self.sym),
-                         ct.DataShape(ct.Option(ct.int32)))
-        self.assertEqual(parse('2 * 3 * option[int32]', self.sym),
-                         ct.DataShape(ct.Fixed(2), ct.Fixed(3),
-                                      ct.Option(ct.int32)))
-        self.assertEqual(parse('2 * 3 * ?int32', self.sym),
-                         ct.DataShape(ct.Fixed(2), ct.Fixed(3),
-                                      ct.Option(ct.int32)))
-        self.assertEqual(parse('2 * option[3 * int32]', self.sym),
-                         ct.DataShape(ct.Fixed(2),
-                                      ct.Option(ct.DataShape(ct.Fixed(3),
-                                                             ct.int32))))
-        self.assertEqual(parse('2 * ?3 * int32', self.sym),
-                         ct.DataShape(ct.Fixed(2),
-                                      ct.Option(ct.DataShape(ct.Fixed(3),
-                                                             ct.int32))))
+        assert_dshape_equal(parse('option[int32]', self.sym),
+                            ct.DataShape(ct.Option(ct.int32)))
+        assert_dshape_equal(parse('?int32', self.sym),
+                            ct.DataShape(ct.Option(ct.int32)))
+        assert_dshape_equal(parse('2 * 3 * option[int32]', self.sym),
+                            ct.DataShape(ct.Fixed(2), ct.Fixed(3),
+                                         ct.Option(ct.int32)))
+        assert_dshape_equal(parse('2 * 3 * ?int32', self.sym),
+                            ct.DataShape(ct.Fixed(2), ct.Fixed(3),
+                                         ct.Option(ct.int32)))
+        assert_dshape_equal(parse('2 * option[3 * int32]', self.sym),
+                            ct.DataShape(ct.Fixed(2),
+                                         ct.Option(ct.DataShape(ct.Fixed(3),
+                                                                ct.int32))))
+        assert_dshape_equal(parse('2 * ?3 * int32', self.sym),
+                            ct.DataShape(ct.Fixed(2),
+                                         ct.Option(ct.DataShape(ct.Fixed(3),
+                                                                ct.int32))))
+        assert_dshape_equal(
+            parse('??int32', self.sym),
+            ct.DataShape(ct.Option(ct.Option(ct.int32))),
+        )
 
     def test_raise(self):
         self.assertRaises(datashape.DataShapeSyntaxError,

--- a/docs/source/whatsnew/0.5.0.txt
+++ b/docs/source/whatsnew/0.5.0.txt
@@ -52,6 +52,8 @@ API Changes
      Decimal(precision=11, scale=2)
 * Fields are now always constructed with ``str`` in Record datashapes
   (:issue:`197`).
+* Allow options of options with the syntax: ``??A``. This can be further
+  chained (:issue:`199`).
 
 Bug Fixes
 ---------
@@ -62,6 +64,9 @@ Bug Fixes
 * Fix discovery of strings that start with things that look like numbers
   (:issue:`190`).
 * Makes the parser recognize ``object`` (:issue:`193`).
+* Make :class:`datashape.error.DataShapeSyntaxError` no longer a subclass
+  of ``SyntaxError``. This caused the repl and IPython to display the errors
+  incorrectly (:issue:`199`).
 
 Miscellaneous
 -------------


### PR DESCRIPTION
The syntax is `??A`. This can be further stacked.
