### PR TITLE
resolves bug with python3+pymysql

### DIFF
--- a/datashape/coretypes.py
+++ b/datashape/coretypes.py
@@ -355,6 +355,7 @@ _canonical_string_encodings = {
     u'utf-8': u'U8',
     u'utf_8': u'U8',
     u'utf8': u'U8',
+    u'utf8_bin':u'U8', 
     u'U16': u'U16',
     u'utf-16': u'U16',
     u'utf_16': u'U16',


### PR DESCRIPTION
Using python 3

```python
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
/Users/vassr/.virtualenvs/gapsincare/lib/python3.5/site-packages/datashape/coretypes.py in __init__(self, *args)
    395         try:
--> 396             encoding = _canonical_string_encodings[encoding]
    397         except KeyError:

KeyError: 'utf8_bin'

During handling of the above exception, another exception occurred:

ValueError                                Traceback (most recent call last)
<ipython-input-50-d24c1eaedb48> in <module>()
      1 
      2 
----> 3 claims = blaze.Data(db.url)

/Users/vassr/.virtualenvs/gapsincare/lib/python3.5/site-packages/blaze/interactive.py in Data(data, dshape, name, fields, schema, **kwargs)
    117         dshape = datashape.dshape(dshape)
    118     if not dshape:
--> 119         dshape = discover(data)
    120         types = None
    121         if isinstance(dshape.measure, Tuple) and fields:

/Users/vassr/.virtualenvs/gapsincare/lib/python3.5/site-packages/multipledispatch/dispatcher.py in __call__(self, *args, **kwargs)
    162             self._cache[types] = func
    163         try:
--> 164             return func(*args, **kwargs)
    165 
    166         except MDNotImplementedError:

/Users/vassr/.virtualenvs/gapsincare/lib/python3.5/site-packages/odo/backends/sql.py in discover(engine)
    259 @dispatch(sa.engine.base.Engine)
    260 def discover(engine):
--> 261     return discover(metadata_of_engine(engine))
    262 
    263 

/Users/vassr/.virtualenvs/gapsincare/lib/python3.5/site-packages/multipledispatch/dispatcher.py in __call__(self, *args, **kwargs)
    162             self._cache[types] = func
    163         try:
--> 164             return func(*args, **kwargs)
    165 
    166         except MDNotImplementedError:

/Users/vassr/.virtualenvs/gapsincare/lib/python3.5/site-packages/odo/backends/sql.py in discover(metadata)
    272         name = table.name
    273         try:
--> 274             pairs.append([name, discover(table)])
    275         except sa.exc.CompileError as e:
    276             print("Can not discover type of table %s.\n" % name +

/Users/vassr/.virtualenvs/gapsincare/lib/python3.5/site-packages/multipledispatch/dispatcher.py in __call__(self, *args, **kwargs)
    162             self._cache[types] = func
    163         try:
--> 164             return func(*args, **kwargs)
    165 
    166         except MDNotImplementedError:

/Users/vassr/.virtualenvs/gapsincare/lib/python3.5/site-packages/odo/backends/sql.py in discover_sqlalchemy_selectable(t)
    201 def discover_sqlalchemy_selectable(t):
    202     ordering = dict((c, i) for i, c in enumerate(c for c in t.columns.keys()))
--> 203     records = list(sum([discover(c).parameters[0] for c in t.columns], ()))
    204     fkeys = [discover(fkey, t, parent_measure=Record(records))
    205              for fkey in t.foreign_keys]

/Users/vassr/.virtualenvs/gapsincare/lib/python3.5/site-packages/odo/backends/sql.py in <listcomp>(.0)
    201 def discover_sqlalchemy_selectable(t):
    202     ordering = dict((c, i) for i, c in enumerate(c for c in t.columns.keys()))
--> 203     records = list(sum([discover(c).parameters[0] for c in t.columns], ()))
    204     fkeys = [discover(fkey, t, parent_measure=Record(records))
    205              for fkey in t.foreign_keys]

/Users/vassr/.virtualenvs/gapsincare/lib/python3.5/site-packages/multipledispatch/dispatcher.py in __call__(self, *args, **kwargs)
    162             self._cache[types] = func
    163         try:
--> 164             return func(*args, **kwargs)
    165 
    166         except MDNotImplementedError:

/Users/vassr/.virtualenvs/gapsincare/lib/python3.5/site-packages/odo/backends/sql.py in discover_sqlalchemy_column(c)
    195 def discover_sqlalchemy_column(c):
    196     meta = Option if c.nullable else identity
--> 197     return Record([(c.name, meta(discover(c.type)))])
    198 
    199 

/Users/vassr/.virtualenvs/gapsincare/lib/python3.5/site-packages/multipledispatch/dispatcher.py in __call__(self, *args, **kwargs)
    162             self._cache[types] = func
    163         try:
--> 164             return func(*args, **kwargs)
    165 
    166         except MDNotImplementedError:

/Users/vassr/.virtualenvs/gapsincare/lib/python3.5/site-packages/odo/backends/sql.py in discover_typeengine(typ)
    173         return datashape.Decimal(precision=typ.precision, scale=typ.scale)
    174     if isinstance(typ, (sa.String, sa.Unicode)):
--> 175         return datashape.String(typ.length, typ.collation)
    176     else:
    177         for k, v in revtypes.items():

/Users/vassr/.virtualenvs/gapsincare/lib/python3.5/site-packages/datashape/coretypes.py in __init__(self, *args)
    397         except KeyError:
    398             raise ValueError('Unsupported string encoding %s' %
--> 399                              repr(encoding))
    400 
    401         self.encoding = encoding

ValueError: Unsupported string encoding 'utf8_bin'
```
despite all manner of connection string permutations (with charset specification, without...etc), create_engine strategies, etc, blaze had trouble reading a mysql database that sqlalchemy, and, for that matter, pandas, had no issue with. using latest versions of everything

adding this key to the `_canonical_string_encodings `  resolved this error