### PR TITLE
Generalize `Mono.__eq__` to handle equality among subclasses.

### DIFF
--- a/datashape/coretypes.py
+++ b/datashape/coretypes.py
@@ -87,7 +87,7 @@ class Mono(with_metaclass(Type, object)):
         return type(self), self.parameters
 
     def __eq__(self, other):
-        return (issubclass(type(other), Mono) and
+        return (isinstance(other, Mono) and
                 self.shape == other.shape and
                 self.measure.info() == other.measure.info())
 
@@ -98,7 +98,7 @@ class Mono(with_metaclass(Type, object)):
         try:
             h = self._hash
         except AttributeError:
-            h = self._hash = hash(self.info())
+            h = self._hash = hash(self.shape) ^ hash(self.measure.info())
         return h
 
     @property

--- a/datashape/coretypes.py
+++ b/datashape/coretypes.py
@@ -87,7 +87,9 @@ class Mono(with_metaclass(Type, object)):
         return type(self), self.parameters
 
     def __eq__(self, other):
-        return type(self) == type(other) and self.info() == other.info()
+        return (issubclass(type(other), Mono) and
+                self.shape == other.shape and
+                self.measure.info() == other.measure.info())
 
     def __ne__(self, other):
         return not self.__eq__(other)

--- a/datashape/tests/test_coretypes.py
+++ b/datashape/tests/test_coretypes.py
@@ -33,7 +33,7 @@ from datashape.coretypes import (
 )
 from datashape import (dshape, to_numpy_dtype, from_numpy, error, Units,
                        uint32, Bytes, var, timedelta_, datetime_, date_,
-                       float64, Tuple, to_numpy)
+                       float64, Tuple, to_numpy, string)
 from datashape.py2help import unicode, OrderedDict
 
 
@@ -649,3 +649,17 @@ def test_unicode_record_names(names, typ):
     assert record.names == names
     assert record.types == types
     assert all(isinstance(s, string_type) for s in record.names)
+
+
+equiv_dshape_pairs = [(dshape('?string'), Option('string')),
+                      (dshape('string'), string),
+                      (dshape('datetime'), datetime_),
+                      (dshape('?datetime'), Option(datetime_)),
+                      (dshape('10 * int32'), 10 * int32),
+                      (dshape('var * ?int32'), var * Option(int32)),
+                      (dshape('10 * ?float64'), Fixed(10) * Option(float64))]
+
+@pytest.mark.parametrize('a,b', equiv_dshape_pairs)
+def test_hash_and_eq_consistency(a, b):
+    assert a == b
+    assert hash(a) == hash(b)

--- a/datashape/tests/test_promote.py
+++ b/datashape/tests/test_promote.py
@@ -1,7 +1,8 @@
 import pytest
 
 from datashape import (promote, Option, float64, int64, float32, optionify,
-                       string, datetime_ as datetime)
+                       string, datetime_ as datetime, dshape)
+
 
 def test_simple():
     x = int64
@@ -53,6 +54,26 @@ def test_option_in_parent():
                           [Option(string),
                            string,
                            False,
+                           string],
+
+                          [Option(string),
+                           dshape('?string'),
+                           True,
+                           Option(string)],
+
+                          [dshape('?string'),
+                           Option(string),
+                           False,
+                           Option(string)],
+
+                          [dshape('string'),
+                           Option(string),
+                           True,
+                           Option(string)],
+
+                          [dshape('string'),
+                           Option(string),
+                           False,
                            string]])
 def test_promote_string_with_option(x, y, p, r):
     assert (promote(x, y, promote_option=p) ==
@@ -81,6 +102,26 @@ def test_promote_string_with_option(x, y, p, r):
 
                           [Option(datetime),
                            datetime,
+                           False,
+                           datetime],
+
+                          [Option(datetime),
+                           dshape('?datetime'),
+                           True,
+                           Option(datetime)],
+
+                          [dshape('?datetime'),
+                           Option(datetime),
+                           False,
+                           Option(datetime)],
+
+                          [dshape('datetime'),
+                           Option(datetime),
+                           True,
+                           Option(datetime)],
+
+                          [dshape('datetime'),
+                           Option(datetime),
                            False,
                            datetime]])
 def test_promote_datetime_with_option(x, y, p, r):

--- a/docs/source/whatsnew/0.5.3.txt
+++ b/docs/source/whatsnew/0.5.3.txt
@@ -1,0 +1,42 @@
+Release |version|
+-----------------
+
+:Release: |version|
+:Date: TBD
+
+New Features
+------------
+
+None
+
+New Types
+---------
+
+None
+
+Experimental Types
+------------------
+
+.. warning::
+
+   Experimental types are subject to change.
+
+None
+
+API Changes
+-----------
+
+None
+
+Bug Fixes
+---------
+
+* Fixes :func:`~coretypes.Mono.__eq__` to ensure equality among
+  :class:`~coretypes.Mono` subclasses compare equal when it makes sense to do so.
+  For instance ``dshape("?string") == Option(string)`` now holds true
+  (:issue:`214`).
+
+Miscellaneous
+-------------
+
+None


### PR DESCRIPTION
Ensures `dshape('?string') == Option(string)` holds true.

ping @richafrank @llllllllll 