### PR TITLE
Record order recursion

### DIFF
--- a/datashape/util/testing.py
+++ b/datashape/util/testing.py
@@ -195,7 +195,7 @@ def assert_dshape_equal(a, b, check_record_order=True, path=None, **kwargs):
 
     assert len(afields) == len(bfields), \
         'records have mismatched field counts: %d != %d\n%r != %r\n%s' % (
-            len(afields), len(bfields), a, b, _fmt_path(path),
+            len(afields), len(bfields), a.names, b.names, _fmt_path(path),
         )
 
     if not check_record_order:
@@ -216,6 +216,7 @@ def assert_dshape_equal(a, b, check_record_order=True, path=None, **kwargs):
             afield,
             bfield,
             path=path + ('[%s]' % repr(aname),),
+            check_record_order=check_record_order,
             **kwargs
         )
 

--- a/datashape/util/tests/test_testing.py
+++ b/datashape/util/tests/test_testing.py
@@ -6,7 +6,7 @@ import pytest
 
 from datashape.coretypes import (
     DateTime,
-    Record,
+    R,
     String,
     Time,
     TimeDelta,
@@ -68,35 +68,35 @@ def test_dim():
 
 def test_record():
     assert_dshape_equal(
-        Record((('a', int32), ('b', float32))),
-        Record((('a', int32), ('b', float32))),
+        R['a': int32, 'b': float32],
+        R['a': int32, 'b': float32],
     )
 
     with pytest.raises(AssertionError) as e:
         assert_dshape_equal(
-            Record((('a', int32), ('b', float32))),
-            Record((('a', int32), ('b', int32))),
+            R['a': int32, 'b': float32],
+            R['a': int32, 'b': int32],
         )
     assert "'float32' != 'int32'" in str(e)
     assert "_['b'].name" in str(e.value)
 
     with pytest.raises(AssertionError) as e:
         assert_dshape_equal(
-            Record((('a', int32), ('b', float32))),
-            Record((('a', int32), ('c', float32))),
+            R['a': int32, 'b': float32],
+            R['a': int32, 'c': float32],
         )
     assert "'b' != 'c'" in str(e.value)
 
     assert_dshape_equal(
-        Record((('b', float32), ('a', int32))),
-        Record((('a', int32), ('b', float32))),
+        R['b': float32, 'a': int32],
+        R['a': int32, 'b': float32],
         check_record_order=False,
     )
 
     with pytest.raises(AssertionError) as e:
         assert_dshape_equal(
-            Record((('b', float32), ('a', float32))),
-            Record((('a', int32), ('b', float32))),
+            R['b': float32, 'a': float32],
+            R['a': int32, 'b': float32],
             check_record_order=False,
         )
     assert "'float32' != 'int32'" in str(e.value)

--- a/datashape/util/tests/test_testing.py
+++ b/datashape/util/tests/test_testing.py
@@ -87,12 +87,6 @@ def test_record():
         )
     assert "'b' != 'c'" in str(e.value)
 
-    assert_dshape_equal(
-        R['b': float32, 'a': int32],
-        R['a': int32, 'b': float32],
-        check_record_order=False,
-    )
-
     with pytest.raises(AssertionError) as e:
         assert_dshape_equal(
             R['b': float32, 'a': float32],
@@ -100,6 +94,28 @@ def test_record():
             check_record_order=False,
         )
     assert "'float32' != 'int32'" in str(e.value)
+    assert "_['a']" in str(e.value)
+
+    assert_dshape_equal(
+        R['b': float32, 'a': int32],
+        R['a': int32, 'b': float32],
+        check_record_order=False,
+    )
+
+    # check a nested record with and without ordering
+    assert_dshape_equal(
+        R['a': R['b': float32, 'a': int32]],
+        R['a': R['a': int32, 'b': float32]],
+        check_record_order=False,
+    )
+
+    with pytest.raises(AssertionError) as e:
+        assert_dshape_equal(
+            R['a': R['a': int32, 'b': float32]],
+            R['a': R['b': float32, 'a': int32]],
+        )
+
+    assert "'a' != 'b'" in str(e.value)
     assert "_['a']" in str(e.value)
 
 


### PR DESCRIPTION
the change in `testing.py` is because I had two datashapes that over 1k lines long each. All anyone wants to know in this case is what the _names_ of the fields are.