### PR TITLE
BUG: bool data type not converting, when it should

### DIFF
--- a/datashape/coretypes.py
+++ b/datashape/coretypes.py
@@ -741,6 +741,8 @@ class Option(Mono):
     def to_numpy_dtype(self):
         if type(self.ty) in numpy_provides_missing:
             return self.ty.to_numpy_dtype()
+        if isinstance(self.ty, CType) and (self.ty.name == 'bool'):
+            return self.ty.to_numpy_dtype()
         raise TypeError('DataShape measure %s is not NumPy-compatible' % self)
 
 


### PR DESCRIPTION
Hello,

This resolves (for me at least) #208. 

I have a MSSQL table with a `bit` data column. In `odo`, we are converting that to `bool`, which is fine. However, `bool` types throw an error here. I'm not an expert on what is supposed to be going on here, but this gets it to work for me. 

Thanks. 
