### PR TITLE
Fix LICENSE format

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -11,6 +11,7 @@ this list of conditions and the following disclaimer.
 Redistributions in binary form must reproduce the above copyright
 notice, this list of conditions and the following disclaimer in the
 documentation and/or other materials provided with the distribution.
+
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR


### PR DESCRIPTION
Add a newline to fix the format of the `LICENSE` file. This should hopefully make GitHub realize this is BSD 3-Clause instead of BSD 2-Clause.