### PR TITLE
Allow for handling Map types in conversion to numpy dtypes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ coverage.xml
 
 # Sphinx documentation
 docs/_build/
+
+# IDE
+.idea/

--- a/datashape/coretypes.py
+++ b/datashape/coretypes.py
@@ -364,7 +364,7 @@ _canonical_string_encodings = {
     u'U32': u'U32',
     u'utf-32': u'U32',
     u'utf_32': u'U32',
-    u'utf32': u'U32'
+    u'utf32': u'U32',
 }
 
 
@@ -907,6 +907,9 @@ class Map(Mono):
                                self.key,
                                self.value)
 
+    def to_numpy_dtype(self):
+        return to_numpy_dtype(self)
+
 
 def _launder(x):
     """ Clean up types prior to insertion into DataShape
@@ -1276,6 +1279,8 @@ var = Var()
 def to_numpy_dtype(ds):
     """ Throw away the shape information and just return the
     measure as NumPy dtype instance."""
+    if isinstance(ds.measure, datashape.coretypes.Map):
+        ds = ds.measure.key
     return to_numpy(ds.measure)[1]
 
 

--- a/datashape/tests/test_coretypes.py
+++ b/datashape/tests/test_coretypes.py
@@ -590,8 +590,7 @@ def test_map():
     assert fk.value == Record([('a', int32)])
     assert fk.value.dict == {'a': int32}
     assert fk.value.fields == (('a', int32),)
-    with pytest.raises(TypeError):
-        fk.to_numpy_dtype()
+    assert fk.to_numpy_dtype() == np.dtype('int32')
 
 
 def test_map_parse():


### PR DESCRIPTION
This PR simply keeps the key, ignoring the mapped (foreign-key) table. The idea being that a lossy conversion is better than throwing an exception and the user can always incorporate the foreign-key table if that's what they want by doing an explicit join beforehand.

Attn: @llllllllll (blaze/odo#534)