### PR TITLE
ENH: don't re-validate args when unpickling

### DIFF
--- a/datashape/coretypes.py
+++ b/datashape/coretypes.py
@@ -710,7 +710,9 @@ class DataShape(Mono):
                         (index, type(index).__name__))
 
     def __setstate__(self, state):
-        self.__init__(*state)
+        self._parameters = state
+        self.composite = True
+        self.name = None
 
 
 numpy_provides_missing = frozenset((Date, DateTime, TimeDelta))


### PR DESCRIPTION
The validation can be very expensive for large datashapes.