### PR TITLE
Fix support for setting "bytes" as datatype

### DIFF
--- a/datashape/discovery.py
+++ b/datashape/discovery.py
@@ -11,10 +11,10 @@ from dateutil.parser import parse as dateparse
 import numpy as np
 
 from .dispatch import dispatch
-from .coretypes import (int32, int64, float64, bool_, complex128, datetime_,
+from .coretypes import (int32, int64, float64, bool_, bytes_, complex128, datetime_,
                         Option, var, from_numpy, Tuple, null,
                         Record, string, Null, DataShape, real, date_, time_,
-                        Unit, timedelta_, TimeDelta, object_, String)
+                        Unit, timedelta_, TimeDelta, object_)
 from .predicates import isdimension, isrecord
 from .py2help import _strtypes, _inttypes, MappingProxyType, OrderedDict
 from .internal_utils import _toposort, groupby
@@ -81,7 +81,7 @@ npinttypes = tuple(chain.from_iterable((x for x in subclasses(icls)
 if sys.version_info[0] == 3:
     @dispatch(bytes)
     def discover(b):
-        return String('A')
+        return bytes_
 
 
 @dispatch(npinttypes)

--- a/datashape/type_symbol_table.py
+++ b/datashape/type_symbol_table.py
@@ -72,6 +72,7 @@ no_constructor_types = [
     ('real', ct.float64),
     ('complex', ct.complex_float64),
     ('string', ct.string),
+    ('bytes', ct.bytes_),
     ('json', ct.json),
     ('date', ct.date_),
     ('time', ct.time_),


### PR DESCRIPTION
This fixes #230. This fix enables using 'bytes' type like this:

```py
datashape.dshape('{foo: bytes}')
```

To verify this fix, you can run:

```sh
conda create -y -n datashape_test python=2.7 
conda activate datashape_test
conda install -y --file requirements.txt
python -c "import datashape; my_shape = datashape.dshape('{foo: bytes}'); print(my_shape)" # WORKS!
git checkout HEAD^
python -c "import datashape; my_shape = datashape.dshape('{foo: bytes}'); print(my_shape)" # fails...
git checkout fix_bytes_support
conda deactivate

# To try with another py version, just:
conda env remove -n datashape_test
conda create -y -n datashape_test python=3.7
# Then repeat the steps from above starting from the "conda install ..." line
```

In practice I tested a datashape with "bytes" to help me serialize and deserialize bytes data and it worked perfectly.

Note that I suspect the CI failures to be false failures. Locally all tests succeed on the py versions I tested (2.7 and 3.7). For example, this PR has the same failures: https://travis-ci.org/github/blaze/datashape/builds/705165599